### PR TITLE
Adding CPX/AML minimal documentation + fixing broken links

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -6,6 +6,7 @@
 
 | Date | Version  | Comment |
 |:----:|:-------:|:-------|
+| 3rd Nov 2023 | 5.2.2  | Addition of preview documentation for upcoming new formats CPX and AML
 | 3rd Nov 2023 | 5.2.1  | Addition of documentation for Colorized Sub-aperture Image (CSI) and SAR Video (VID) produtcs
 | 13th Jun 2023 | 5.2.0  | Addition of Spot Fine Imaging Characteristics and Data Product Parameters. Fleet summary modified to reflect capabilities of new Generation 3 satellites.
 | 1st Feb 2023 | 5.1.2  | Addition of Spot Extended Dwell Imaging Characteristics

--- a/docs/productFormats/img/QGIS-CPX.png
+++ b/docs/productFormats/img/QGIS-CPX.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2cb94beb7b04bff5f9bb93163cd885d96060e8eddb9b0cb7caf7e1aee18ff79c
+size 65895

--- a/docs/productFormats/img/cpx_dwell_zoomed_in.png
+++ b/docs/productFormats/img/cpx_dwell_zoomed_in.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3d11319b33928ba125f7deb0e21653ff7e40c234c0b971156268628a8305ad6
+size 1916351

--- a/docs/productFormats/img/cpx_dwell_zoomed_out.png
+++ b/docs/productFormats/img/cpx_dwell_zoomed_out.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02f73057622892203a5c4cf0ff010481287db25156a7845320e5a73822fd66bf
+size 1973682

--- a/docs/productFormats/img/cpx_preview.png
+++ b/docs/productFormats/img/cpx_preview.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c03e13ead716c34d7e8133e3f5a321087ef8bbfbedc0c00c7170adf57224337
+size 1794909

--- a/docs/productFormats/img/grd_preview.png
+++ b/docs/productFormats/img/grd_preview.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77d8ebf1c6231a0877e73d73af5af4474107686c788067a16ad959e444c4ccb4
+size 786946

--- a/docs/productFormats/img/imaging_geometry.png
+++ b/docs/productFormats/img/imaging_geometry.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:efcf8024415b3aaacacdb03adc1e86e39404c0c7e7b0fb15d281a4ea1373922b
+size 3543261

--- a/docs/productFormats/upcomingformats.md
+++ b/docs/productFormats/upcomingformats.md
@@ -1,0 +1,90 @@
+!!! info 
+    The data formats described in this page are available as a preview and can be provided to ICEYE customers upon request. More information in the FAQ. 
+
+We are excited to provide a preview of upcoming new formats for our complex and amplitude data products as well as their corresponding metadata format. These new formats attempt to lower the barriers for getting the maximum value out of ICEYE SAR data: They are more user friendly, and compatible with more GIS and image viewing software and web applications. They also offer easier access to  all the information they contain without the need for specialized scientific tools or advanced SAR knowledge.
+
+## CPX: Complex Image (Preview)
+
+### The challenge with complex data
+
+SAR complex data has traditionally been packaged in scientific or military-intel formats like [SLC](../slc) ([HDF container](../slc#hdf5-container)) or ([SICD](../slc#sensor-independent-complex-data-sicd)) ([NITF container](../slc#sensor-independent-complex-data-sicd)) where each image pixel is stored with in-phase I and quadrature Q components and therefore, contains both amplitude and phase information. These formats require compliant tools and software that is currently difficult to use without specialized skill and experience. For this reason, the user of complex images has been limited to automated processing and advanced exploitation such as interferometric applications, or by users who prefer lower-level processing in order to implement their own processing chains. 
+
+### CPX is complex data in a GeoTiff
+
+CPX images are packaged in the open, international [GeoTiff](https://en.wikipedia.org/wiki/GeoTIFF) format. This enables their easy ingestion and manipulation in most image readers, GIS tools and libraries. The amplitude and phase data is formatted in two GeoTiff bands, similar to how bands are used for multispectral images. Image readers and GIS tools are able to ingest this complex image just like they do any other GeoTiff file. The amplitude band can be immediately presented for viewing, while the phase band is available for further exploitation by more specialized tools. **The key advantage is that the CPX image is at full resolution, so users have access to the full resolution as well as to reduced-speckle, pixel-ageraged views (equivalent to different levels of multi-looking) that are produced instantly when zooming in and out.** 
+
+While the SAR data inside the CPX format is stored in the slant plane (the satellite image acquisition geometry), the metadata in the CPX format contains [RPC values](../../foundations/geospatialAccuracy/#fast-and-simple-geolocation-rapid-positioning-capability) that allows GIS tools to perform automatic ground projection, so they  are ready to be used as part of analysis and exploitation workflows. Please note that Orthorectification using a Digital Elevation Model is still recommended for accurate geospatial comparison and analysis.
+
+THe CPX format uses the [Cloud-Optimized GeoTIFF](https://docs.ogc.org/is/21-026/21-026.html) standard that allows fast data visualization and geospatial processing workflows. GIS applications can efficiently stream or download only the parts of the information they need to visualize or process web-based data. Tiles and overviews are included to enable fast image rendering. CPX files accessed by web applications or stored online can be efficiently streamed and partially downloaded with the use of HTTP range queries. 
+
+<figure markdown>
+![placeholder](img/grd_preview.png){width="800"}
+<figcaption align = "center"><em>Figure 1: Detail of a Dwell GRD viewed in QGIS. Squared pixels are limited by range resolution </em></figcaption>
+![placeholder](img/cpx_preview.png){width="800"}
+<figcaption align = "center"><em>Figure 2: Detail of a Dwell CPX viewed in QGIS. Full azimuth resolution visible without the need for scientific viewing software. </em></figcaption>
+</figure> 
+
+### Recommended QGIS settings
+
+The following settings are recommended when using [QGIS](https://qgis.org/) to visualize CPX images. They ensure that the correct render type and optimal resampling method is used to display the amplitude band. 
+
+<figure markdown>
+![placeholder](img/QGIS-CPX.png){width="800"}
+<figcaption align = "center"><em>Figure 3: Recommended QGIS settings for exploiting the CPX format.</em></figcaption>
+</figure> 
+
+1. Select <code>Layer Properties -> Symbology</code>
+1. Under <code>Band Rendering</code>
+    * Render type: <code>Singleband gray</code>
+    * Gray band: <code>Band 1 (Gray)</code>
+1. Under Contrast enhancement, start with <code>Cumulative count cut 2 - 98%</code>, and adjust if necessary
+1. Under Resampling
+    * Early resampling: <code>On</code>
+    * Zoomed in: <code>Lanczos</code>
+    * Zoomed out: <code>Lanczos</code>
+
+**Explanation:** Although CPX image has a single look, QGIS performs [Lanczos averaging](https://en.wikipedia.org/wiki/Lanczos_resampling) when rendering to make the projection correct. This is equivalent to multilooking, but the software is doing it in real time. The user gets the benefit of reduced speckle when zoomed out and the benefit of the finest resolution when zoomed in.
+
+<figure markdown>
+![placeholder](img/cpx_dwell_zoomed_out.png){width="800"}
+<figcaption align = "center"><em>Figure 4: Zoomed out image showing reduced speckle because of Lanczos averaging (multi-looking) </em></figcaption>
+![placeholder](img/cpx_dwell_zoomed_in.png){width="800"}
+<figcaption align = "center"><em>Figure 5: Zoomed in image showing speckle but also higher azimuth resolution  </em></figcaption>
+</figure> 
+
+
+## AML: Amplitude Multi-looked Image (Preview)
+
+AML images contain the amplitude part of the backscattering signal. They are a more user friendly implementation of the current [GRD](../grd) format.
+The AML format uses the [Cloud-Optimized GeoTIFF standard](https://docs.ogc.org/is/21-026/21-026.html) and offers the following advantages:
+
+* Supported by most image viewing software, GIS applications, data exploitation tools and libraries.
+* Allows for faster data visualization and geospatial processing workflows.  Applications can efficiently stream/download only the parts of the information they need to visualize data. Tiles and overviews are included to enable fast image rendering. AML files accessed by web applications or stored online can be efficiently streamed and partially downloaded with the use of HTTP range queries.
+* The AML format allows for increased data precision (u32/f32) to support the very high dynamic range of the latest ICEYE data product.
+* Defaults to shadows-down data orientation to facilitate interpretation of topography and elevated features
+
+
+## Metadata 3.0 (Preview)
+
+The metadata of the new CPX and AML image formats is stored in [GeoJSON](https://en.wikipedia.org/wiki/GeoJSON) format which is more modern than the XML used to store metadata by the current [SLC](../slc) and [GRD](../grd) formats. GeoJSON is a geocoded metadata format supported by many GIS tools.  
+
+The included satellite orbit metadata can be used to visualize the exact position of the satellite when the SAR data was collected as well as the imaging geometry. 
+
+A JSON schema that can be used for validation purposes is available at the following location:
+
+[https://sar.iceye.com/schema/product-spec/0.0.1/image.json](https://sar.iceye.com/schema/product-spec/0.0.1/image.json) 
+
+<figure markdown>
+![placeholder](img/imaging_geometry.png){width="800"}
+<figcaption align = "center"><em>Figure 6: Imaging geometry and satellite orbit track can be visualized by opening the AML/CPX metadata files Google Earth Pro</em></figcaption>
+</figure> 
+
+
+## Frequently asked questions
+
+### Are CPX and AML available to ICEYE customers?
+Yes, both formats are available as a preview and can be provided to customers upon request. ICEYE encourages customers to try these new product formats and provide us with feedback. We look forward to continuing to develop and improve all our data products.
+
+### Will CPX or AML eventually replace any of the existing formats currently offered by ICEYE?
+Based on customer feedback, ICEYE may decide to adjust its product format offering in the future. There is currently no planned timeline for this. 
+

--- a/docs/productFormats/upcomingformats.md
+++ b/docs/productFormats/upcomingformats.md
@@ -72,7 +72,7 @@ The included satellite orbit metadata can be used to visualize the exact positio
 
 A JSON schema that can be used for validation purposes is available at the following location:
 
-[https://sar.iceye.com/schema/product-spec/0.0.1/image.json](https://sar.iceye.com/schema/product-spec/0.0.1/image.json) 
+[https://sar.iceye.com/schema/product-spec/0.0.2/image.json](https://sar.iceye.com/schema/product-spec/0.0.2/image.json) 
 
 <figure markdown>
 ![placeholder](img/imaging_geometry.png){width="800"}

--- a/docs/productguide/sardataproducts.md
+++ b/docs/productguide/sardataproducts.md
@@ -4,11 +4,11 @@
 
 SAR data can be made into a multitude of different product types. Some are better suited for human exploitation whereas others are better exploited by algorithms and signal-processing tools.
 
-On this page we describe the different SAR data products that ICEYE provides. Technical details about the format of these products, with some tips on how the use them are provided in the section on ['Techinal Information'](../technical/productFormats/introduction.md).
+On this page we describe the different SAR data products that ICEYE provides. Technical details about the format of these products, with some tips on how the use them are provided in the section on ['Technical Information'](../../productFormats/introduction).
 
 !!! info
 
-    The section ["What is SAR?"](../technical/foundations/OverviewOfSAR/overviewOfSAR.md) provides a review of the technologies mentioned here. 
+    The section ["What is SAR?"](../../foundations/OverviewOfSAR/overviewOfSAR) provides a review of the technologies mentioned here. 
 
 <!---
 There are three different *levels* of SAR data product:
@@ -32,7 +32,7 @@ There are three different *levels* of SAR data product:
 
 Unlike optical imagery, each pixel in a SAR image is represented as a *complex number*. The complex number represents two critical components of SAR imaging, *amplitude* and *phase*. The amplitude of a pixel is a measure of the amount of RADAR energy reflected back to the satellite and displayed as a grey-scale value when we look at a SAR image. The phase component is a measure of the position of the RADAR wave after it has interacted with all the scatterers within the pixel. After image formation, the phase information is usually discarded which reduces the size of the SAR image. Some advanced SAR capabilities such as interferometric SAR (INSAR) or coherent change detection (CCD) makes use of the phase information and therefore needs the complex image samples.
 
-All ICEYE images are available as Complex Datasets (with the exception of SCAN mode collections). More details about complex image file formats can be found in the ['Technical Information'](../technical/productFormats/slc.md) section.
+All ICEYE images are available as Complex Datasets (with the exception of SCAN mode collections). More details about complex image file formats can be found in the ['Technical Information'](../../productFormats/slc) section.
 
 <!---
 <span style="color:darkred">[TODO] make animation showing the nature of a complex image </span>.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ nav:
         - Additional Products :
             - Colorized Sub-aperture Image : productFormats/csi.md
             - SAR Video : productFormats/vid.md
+        - Upcoming Formats : productFormats/upcomingformats.md
         - Metadata : productFormats/metadata.md
     - Foundations : 
       - What is SAR ? : 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,7 +48,6 @@ nav:
     #     - Advanced Tips and Tricks :
     #     - Snippets for Code Ninjas :
     - ICEYE Archives : archive/archive.md
-    - Coming Soon : comingsoon.md
     - About: about.md
 theme:
     name: material


### PR DESCRIPTION
Minimal documentation for upcoming CPX and AML formats as well as their GeoJSON metadata format. 
Also fixed broken link in Types of SAR Data Products" page. 