### PR TITLE
Add open data documentation page

### DIFF
--- a/docs/opendata/opendata.md
+++ b/docs/opendata/opendata.md
@@ -1,4 +1,4 @@
-# Launcing Soon: ICEYE Open Data Program on AWS 🚀
+# ICEYE Open Data Program on AWS 🚀
 
 Welcome to the ICEYE Open Data Program. As part of our commitment to scientific collaboration and advancement, we are making a growing selection of our **Synthetic Aperture Radar (SAR)** datasets available for free under a **Creative Commons Attribution (CC-BY 4.0)** license.
 
@@ -22,7 +22,7 @@ Each SAR scene typically includes:
 The ICEYE Open Data catalog is structured as a [static STAC catalog](https://stacspec.org), hosted as publicly accessible files on Amazon S3. The s3 bucket is organized as follows:
 
 ```text
-s3://iceye-open-data/
+s3://iceye-open-data-catalog/
 ├── catalog.json
 ├── collections/
 │ └── iceye-sar.json
@@ -35,17 +35,45 @@ s3://iceye-open-data/
 │ └── *.json # Metadata
 ```
 
-### 🔍 Finding Data
+## Accessing the ICEYE Open Data Bucket
 
-- **Catalog browsing**: You can use STAC Browser or command-line tools like [`pystac-client`](https://github.com/stac-utils/pystac-client) to crawl and filter the catalog.
-- **Scene organization**: STAC items are grouped by **acquisition date (YYYY/MM)**.
-- **Assets** are linked inside each STAC item, referencing public URLs to their respective COGs and metadata.
+You can access ICEYE’s open data via a public S3 bucket. No AWS credentials or account are required.
 
-For a direct listing of files, visit the [ICEYE Open Data S3 Website](TBD).
+### Resource Details
+
+| **Resource Type**           | **Details**                                                  |
+|----------------------------|--------------------------------------------------------------|
+| **S3 Bucket**              | `iceye-open-data-catalog`                                            |
+| **Amazon Resource Name (ARN)** | `arn:aws:s3:::iceye-open-data-catalog`                      |
+| **AWS Region**             | `us-west-2`                                                  |
+| **AWS CLI Access**         | `aws s3 ls --no-sign-request s3://iceye-open-data-catalog/data/`     |
+
+> **Note**: The `--no-sign-request` flag allows public access without requiring an AWS account.
+
+---
+
+### 🌐 Browse the ICEYE Open Data Catalog
+
+You can explore the contents of the ICEYE Open Data S3 bucket through a web-based file browser:
+
+🔗 [Open the Catalog](http://iceye-open-data-catalog.s3-website-us-west-2.amazonaws.com/?prefix=)
+
+This static website interface allows you to:
+
+- View the available datasets and all the `.tif`, `.json`, and `.png` files included in them
+- Access the image and metadata files directly from your browser
+
+### Browse Data with STAC Browser
+
+You can also explore the dataset using the STAC Browser via the link below:
+
+🔗 [STAC Browser - ICEYE Open Data Catalog](https://radiantearth.github.io/stac-browser/#/external/iceye-open-data-catalog.s3-us-west-2.amazonaws.com/catalog.json?.language=en)
+
+The STAC Browser provides an interactive interface to navigate and preview metadata and available assets.
 
 ## 🧪 Tutorial: Access and Analyze ICEYE SAR Data on AWS
 
-This tutorial walks through how to:
+To get started with the ICEYE open SAR data, you can simply:
 
 1. Discover a scene using STAC tools or by browsing the bucket
 2. Load a COG (Cloud Optimized GeoTIFF) directly from S3

--- a/docs/opendata/opendata.md
+++ b/docs/opendata/opendata.md
@@ -6,9 +6,7 @@ This documentation explains how the data is organized, how to access it via AWS,
 
 ## 📁 Dataset Overview
 
-The ICEYE open data catalog contains high-resolution SAR scenes acquired in different imaging modes.
-
-All products are delivered as **Cloud-Optimized GeoTIFFs (COGs)** and are aligned with the specifications documented in ICEYE’s product documentation.
+All products are delivered as **Cloud-Optimized GeoTIFFs (COGs)** and, where applicable, adhere to the specifications defined in the ICEYE product documentation. Please note, however, that this open catalog contains example datasets and imaging products that may be experimental and/or may not fully comply with the latest data product specifications. For the most up-to-date documentation on commercially available products, please refer to the latest data product specifications available at [static STAC catalog](sar.iceye.com)
 
 Each SAR scene typically includes:
 
@@ -17,7 +15,7 @@ Each SAR scene typically includes:
 - **QLK COG**: Quicklook preview image
 - **Metadata JSON**: STAC compliant image product metadata
 
-Additionally, for spotlight dwell collections, the catalog includes:
+Additionally, collections acquired in Dwell imaging modes, the catalog includes:
 
 - **CSI COG**: Colorized Subaperture image
 - **VID COG**: SAR Video in COG, GIF, and MP4 formats

--- a/docs/opendata/opendata.md
+++ b/docs/opendata/opendata.md
@@ -1,0 +1,68 @@
+# Launcing Soon: ICEYE Open Data Program on AWS 🚀
+
+Welcome to the ICEYE Open Data Program. As part of our commitment to scientific collaboration and advancement, we are making a growing selection of our **Synthetic Aperture Radar (SAR)** datasets available for free under a **Creative Commons Attribution (CC-BY 4.0)** license.
+
+This documentation explains how the data is organized, how to access it via AWS, and provides a tutorial to help users get started with analysis and exploitation!
+
+## 📁 Dataset Overview
+
+The ICEYE open data catalog contains high-resolution SAR scenes acquired in different imaging modes.
+
+All products are delivered as **Cloud-Optimized GeoTIFFs (COGs)** and are aligned with the specifications documented in ICEYE’s product documentation.
+
+Each SAR scene typically includes:
+
+- **GRD COG**: Ground Range Detected image
+- **SLC COG**: Single Look Complex image
+- **QLK PNG**: Compressed preview image, including a .kml file for visualization in Google Earth
+- **Metadata JSON**: Original metadata used to generate STAC
+  
+## 📚 Data Organization
+
+The ICEYE Open Data catalog is structured as a [static STAC catalog](https://stacspec.org), hosted as publicly accessible files on Amazon S3. The s3 bucket is organized as follows:
+
+```text
+s3://iceye-open-data/
+├── catalog.json
+├── collections/
+│ └── iceye-sar.json
+├── stac-items/
+│ └── YYYY/MM/scene_timestamp_product.json
+├── data/
+│ └── <ICEYE_scene_id_timestamp_satellite_mode>/
+│ ├── *.tif # GRD / SLC COGs
+│ ├── *.png # Quicklook
+│ └── *.json # Metadata
+```
+
+### 🔍 Finding Data
+
+- **Catalog browsing**: You can use STAC Browser or command-line tools like [`pystac-client`](https://github.com/stac-utils/pystac-client) to crawl and filter the catalog.
+- **Scene organization**: STAC items are grouped by **acquisition date (YYYY/MM)**.
+- **Assets** are linked inside each STAC item, referencing public URLs to their respective COGs and metadata.
+
+For a direct listing of files, visit the [ICEYE Open Data S3 Website](TBD).
+
+## 🧪 Tutorial: Access and Analyze ICEYE SAR Data on AWS
+
+This tutorial walks through how to:
+
+1. Discover a scene using STAC tools or by browsing the bucket
+2. Load a COG (Cloud Optimized GeoTIFF) directly from S3
+3. Visualize and analyze the image using GIS software or Python
+
+### 🔍 Viewing in GIS Tools
+
+All `.tif` files in this dataset are **Cloud-Optimized GeoTIFFs (COGs)**, which can be opened directly over the network in common GIS tools like:
+
+- **QGIS**: Use the “Raster > Add Layer > Add Raster Layer” menu and paste in the HTTPS S3 URL.
+- **ArcGIS Pro**: Use “Add Data from Path” and specify the public COG URL.
+- **GDAL-based tools**: COGs can be read directly with `gdal_translate`, `gdalinfo`, or used in server workflows like GeoServer or MapServer.
+
+---
+
+## 🎓 Licensing and Use
+
+All data is made available under the **CC-BY 4.0 license**. Users are free to use, modify, and redistribute the data for academic, research, and commercial purposes (with attribution to ICEYE).
+
+We actively encourage academic users, Earth observation researchers, and the broader remote sensing community to explore these high-resolution SAR datasets and incorporate them into their work.

--- a/docs/opendata/opendata.md
+++ b/docs/opendata/opendata.md
@@ -1,4 +1,4 @@
-# ICEYE Open Data Program on AWS 🚀
+# ICEYE Open Data Program on AWS
 
 Welcome to the ICEYE Open Data Program. As part of our commitment to scientific collaboration and advancement, we are making a growing selection of our **Synthetic Aperture Radar (SAR)** datasets available for free under a **Creative Commons Attribution (CC-BY 4.0)** license.
 
@@ -12,33 +12,19 @@ All products are delivered as **Cloud-Optimized GeoTIFFs (COGs)** and are aligne
 
 Each SAR scene typically includes:
 
-- **GRD COG**: Ground Range Detected image
 - **SLC COG**: Single Look Complex image
-- **QLK PNG**: Compressed preview image, including a .kml file for visualization in Google Earth
-- **Metadata JSON**: Original metadata used to generate STAC
+- **GRD COG**: Ground Range Detected image
+- **QLK COG**: Quicklook preview image
+- **Metadata JSON**: STAC compliant image product metadata
+
+Additionally, for spotlight dwell collections, the catalog includes:
+
+- **CSI COG**: Colorized Subaperture image
+- **VID COG**: SAR Video in COG, GIF, and MP4 formats
   
 ## 📚 Data Organization
 
-The ICEYE Open Data catalog is structured as a [static STAC catalog](https://stacspec.org), hosted as publicly accessible files on Amazon S3. The s3 bucket is organized as follows:
-
-```text
-s3://iceye-open-data-catalog/
-├── catalog.json
-├── collections/
-│   └── iceye-sar.json
-├── stac-items/
-│   └── YYYY/MM/<scene_id>_<timestamp>_<product>.json
-├── data/
-│   └── <mode-folder>/                          # e.g., spot-fine, dwell-fine
-│       └── <ICEYE_scene_id_timestamp_satellite_mode>/
-│           ├── *.tif   # GRD / SLC COGs
-│           ├── *.png   # QLK / THM
-│           └── *.json  # Metadata
-```
-
-## Accessing the ICEYE Open Data Bucket
-
-You can access ICEYE’s open data via a public S3 bucket. No AWS credentials or account are required.
+The ICEYE Open Data catalog is a [static STAC catalog](https://stacspec.org) hosted as publicly accessible files on Amazon S3. The data can be accessed directly from a public S3 bucket without requiring an AWS account or credentials.
 
 ### Resource Details
 
@@ -84,9 +70,9 @@ To get started with the ICEYE open SAR data, you can simply:
 
 All `.tif` files in this dataset are **Cloud-Optimized GeoTIFFs (COGs)**, which can be opened directly over the network in common GIS tools like:
 
-- **QGIS**: Use the “Raster > Add Layer > Add Raster Layer” menu and paste in the HTTPS S3 URL.
-- **ArcGIS Pro**: Use “Add Data from Path” and specify the public COG URL.
-- **GDAL-based tools**: COGs can be read directly with `gdal_translate`, `gdalinfo`, or used in server workflows like GeoServer or MapServer.
+- **QGIS**: Use the “Raster > Add Layer > Add Raster Layer” menu and select the tif file.
+- **ArcGIS Pro**: Use “Add Data from Path” and specify the file path or public COG URL.
+- **GDAL-based tools**: COGs can be read directly in GDAL-based applications and libraries that support raster access.
 
 ---
 

--- a/docs/opendata/opendata.md
+++ b/docs/opendata/opendata.md
@@ -25,14 +25,15 @@ The ICEYE Open Data catalog is structured as a [static STAC catalog](https://sta
 s3://iceye-open-data-catalog/
 ├── catalog.json
 ├── collections/
-│ └── iceye-sar.json
+│   └── iceye-sar.json
 ├── stac-items/
-│ └── YYYY/MM/scene_timestamp_product.json
+│   └── YYYY/MM/<scene_id>_<timestamp>_<product>.json
 ├── data/
-│ └── <ICEYE_scene_id_timestamp_satellite_mode>/
-│ ├── *.tif # GRD / SLC COGs
-│ ├── *.png # Quicklook
-│ └── *.json # Metadata
+│   └── <mode-folder>/                          # e.g., spot-fine, dwell-fine
+│       └── <ICEYE_scene_id_timestamp_satellite_mode>/
+│           ├── *.tif   # GRD / SLC COGs
+│           ├── *.png   # QLK / THM
+│           └── *.json  # Metadata
 ```
 
 ## Accessing the ICEYE Open Data Bucket

--- a/docs/opendata/opendata.md
+++ b/docs/opendata/opendata.md
@@ -6,7 +6,7 @@ This documentation explains how the data is organized, how to access it via AWS,
 
 ## 📁 Dataset Overview
 
-All products are delivered as **Cloud-Optimized GeoTIFFs (COGs)** and, where applicable, adhere to the specifications defined in the ICEYE product documentation. Please note, however, that this open catalog contains example datasets and imaging products that may be experimental and/or may not fully comply with the latest data product specifications. For the most up-to-date documentation on commercially available products, please refer to the latest data product specifications available at [static STAC catalog](sar.iceye.com)
+All products are delivered as **Cloud-Optimized GeoTIFFs (COGs)** and, where applicable, adhere to the specifications defined in the ICEYE product documentation. Please note, however, that this open catalog contains example datasets and imaging products that may be experimental and/or may not fully comply with the latest data product specifications. For the most up-to-date documentation on commercially available products, please refer to the latest data product specifications available at [All products are delivered as **Cloud-Optimized GeoTIFFs (COGs)** and, where applicable, adhere to the specifications defined in the ICEYE product documentation. Please note, however, that this open catalog contains example datasets and imaging products that may be experimental and/or may not fully comply with the latest data product specifications. For the most up-to-date documentation on commercially available products, please refer to the latest data product specifications available at [sar.iceye.com](https://sar.iceye.com).
 
 Each SAR scene typically includes:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,7 +50,8 @@ nav:
       - Radiometric Considerations : foundations/radiometric.md 
       - Slant to Ground Conversion : foundations/slantToGround.md
       - Validation : foundations/validation/geospatialValidation.md
-    - ICEYE Archives : archive/archive.md
+    - ICEYE Archives : archive/
+    - ICEYE Open Data : opendata/opendata.md
     - Change Log: changes.md
 #    - About: about.md
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,7 +50,7 @@ nav:
       - Radiometric Considerations : foundations/radiometric.md 
       - Slant to Ground Conversion : foundations/slantToGround.md
       - Validation : foundations/validation/geospatialValidation.md
-    - ICEYE Archives : archive/
+    - ICEYE Archives : archive/archive.md
     - ICEYE Open Data : opendata/opendata.md
     - Change Log: changes.md
 #    - About: about.md


### PR DESCRIPTION
This PR adds a new page describing the ICEYE Open Data Program in the the documentation.

The page describes the program and how to access and use the data. It provides the links to the static website of the bucket as well as the STAC browser.