### PR TITLE
SAR101 Welcome + Chapter 1 but hidden from Nav

### DIFF
--- a/docs/sar101/00_welcome.md
+++ b/docs/sar101/00_welcome.md
@@ -29,7 +29,7 @@ Synthetic Aperture Radar (SAR) is an outstanding remote sensing technique due to
 The SAR101: Foundations material describes why and how all these remarkable capabilities are possible with SAR. It also addresses the fundamental limitations and challenges inherent to SAR imagery, because only by understanding both the advantages and disadvantages can SAR imagery be effectively utilized for demanding applications.
 
 <figure id="figure-1-paris">
-<img src="../img/media/image1.jpeg">
+<img src="https://github.com/sjjsy/product-documentation/releases/download/additional-assets-test/image1-paris.jpeg">
 <figcaption><strong>Figure 1: Paris.</strong> This SAR image over Paris, France features the Arc de Triomphe on the left, the Eiffel Tower on the center, and the Seine river flowing between them. Flat surfaces appear dark and smooth while the metallic Eiffel Tower and other buildings are pronounced. As with all SAR images, it is difficult to tell if this image was acquired day or night, under clear skies or a storm - this is due to the remarkable all-weather collection capabilities of SAR. </figcaption>
 </figure>
 
@@ -70,7 +70,7 @@ The chapters comprising **Part 2** focus on building understanding of SAR image 
   - **Chapter [<span class="underline">10</span>](10_data_products.md) Data Products** presents the most established data products on the market, from the early compensated phase history data products to newer colorized sub-aperture stack images and SAR Video.
 
 <figure id="figure-2-diversity">
-<img src="../img/media/image2.jpeg">
+<img src="https://github.com/sjjsy/product-documentation/releases/download/additional-assets-test/image2-diversity.jpeg">
 <figcaption><strong>Figure 2: Diversity.</strong> A SAR image featuring a mountainous scene with agricultural and residential infrastructure. High quality SAR imagery can enable numerous detection, analysis, monitoring and planning use cases that may be instrumental in operations and research and sometimes also save countless lives.</figcaption>
 </figure>
 

--- a/docs/sar101/00_welcome.md
+++ b/docs/sar101/00_welcome.md
@@ -1,0 +1,91 @@
+# Welcome
+
+This is a learning resource intended to help anyone interested in SAR understand basic SAR fundamentals, theory, and terminology. As an introductory document, it was not written to be comprehensive, yet we believe it provides a foundation on which one can begin their journey through the world of SAR.
+
+!!! note inline end
+
+    The first version of this overview was excerpted with permission from [<span class="underline">The Essentials of SAR</span>](https://www.amazon.com/dp/B09CGKTLZV/ref=cm_sw_em_r_mt_dp_H9NDBJSVREXRK5PA4Z58), by Thomas P. Ager[<sup><span class="underline">1</span></sup>](https://sar.iceye.com/5.2.0/foundations/OverviewOfSAR/overviewOfSAR/#fn:1). \!
+
+For those for whom superficial understanding is sufficient at this point, boldly browse the material: We have tried to leverage clear structuring, descriptive headings, illustrations and other elements to help you optimize your time use.
+
+For those for whom this document is not enough, we urge you to see the list of references and further reading materials at the end\!
+
+Note: While ICEYE specific examples and information appear throughout this document, this material is intended to cover the ideas on which SAR sensors and processors are generally based.
+
+## Why Learn About SAR?
+
+Synthetic Aperture Radar (SAR) is an outstanding remote sensing technique due to several exceptional capabilities, including:
+
+  - **Clear Images In Any Weather**: As a radar-based active sensing technique SAR enables the formation of crisp images, day or night, in almost all weather conditions.
+
+  - **High Resolution Independent of Distance**: One of the outstanding characteristics of SAR is that it is capable of high resolution regardless of how far away the sensor is from the ground. SAR sensors can provide very high resolution, even from space.
+
+  - **Variable Resolution and Coverage**: With a phased array sensor, such as those operated by ICEYE, SAR illumination is controlled electronically, and it can be manipulated to vary resolution and coverage. With a phased array sensor, images can be collected over small areas at high resolution, over medium-sized areas at moderate resolution, or over large areas at coarse resolution.
+
+  - **Precision Geolocation**: SAR measurements are inherently precise. Properly calibrated images can have geolocation accuracy less than the scale of a single pixel for well-defined features.
+
+  - **Coherent Illumination and Diverse Products**: The controlled nature of SAR imaging enables the formation of images and many other products. These include sub-aperture image stacks that highlight glinting features and motion, dense elevation models, precise measurements of surface motion, and amplitude and coherent change images or series.
+
+The SAR101: Foundations material describes why and how all these remarkable capabilities are possible with SAR. It also addresses the fundamental limitations and challenges inherent to SAR imagery, because only by understanding both the advantages and disadvantages can SAR imagery be effectively utilized for demanding applications.
+
+<figure id="figure-1-paris">
+<img src="../img/media/image1.jpeg">
+<figcaption><strong>Figure 1: Paris.</strong> This SAR image over Paris, France features the Arc de Triomphe on the left, the Eiffel Tower on the center, and the Seine river flowing between them. Flat surfaces appear dark and smooth while the metallic Eiffel Tower and other buildings are pronounced. As with all SAR images, it is difficult to tell if this image was acquired day or night, under clear skies or a storm - this is due to the remarkable all-weather collection capabilities of SAR. </figcaption>
+</figure>
+
+## Document Structure
+
+SAR101: Foundations is structured into three parts that build on each other.
+
+### Part 1: What SAR is All About?
+
+**Part 1** consists of the first five chapters which describe the big picture of what SAR imaging is and how it works. While the information offered in these chapters can be considered basic background information, it must be understood to truly grasp topics in subsequent chapters.
+
+  - **Chapter [<span class="underline">1</span>](01_introduction.md) Introduction to SAR** outlines the basic idea of SAR imaging by explaining core concepts and terms such as RADAR, real aperture radar, near and far range, range and azimuth resolution, ultimately describing the innovation of synthetic aperture radar.
+
+  - **Chapter [<span class="underline">2</span>](02_satellite_orbits_and_constellations.md) Satellite Orbits and Constellations** explores the spaceborne nature of SAR by defining terms such as the sun-synchronous orbit and satellite constellation, illustrating how SAR systems function over space and time.
+
+  - **Chapter [<span class="underline">3</span>](03_radar_frequency_bands.md) Radar Frequency Bands** offers an overview on electromagnetic radiation and its spectral diversity and clarifies what different bands are, and how they differ in terms of resolution, penetration, and coherence when used in SAR imaging.
+
+  - **Chapter [<span class="underline">4</span>](04_antennas_and_sar_geometry.md) Antennas and SAR Geometry** dives into how active phased array antennas used in SAR work and the relationship between beamwidth and illumination power. Imaging geometry related terms and angles are also visually illustrated and defined.
+
+  - **Chapter [<span class="underline">5</span>](05_collection_strategies.md) Collection Strategies** describes the three established technical approaches to collecting SAR data, as well as the corresponding trade-offs and use cases.
+
+### Part 2: How are SAR Images Formed?
+
+The chapters comprising **Part 2** focus on building understanding of SAR image resolution and quality, and interpretation. These are highly relevant for anyone working with SAR imagery.
+
+  - **Chapter [<span class="underline">6</span>](06_spatial_resolution_and_geospatial_accuracy.md) Spatial Resolution and Geospatial Accuracy** covers the physical determinants of spatial resolution and geospatial accuracy of SAR images. We discuss how waveform modulation, pulse repetition frequency, pulse bandwidth, and incidence angle all impact slant, azimuth, range and ground resolutions. The impulse response function, nominal resolution, geolocation accuracy, and orthorectification are also discussed in this chapter.
+
+  - **Chapter [<span class="underline">7</span>](07_separating_signals_from_noise.md) Separating Signals from Noise** introduces the Radar Range Equation and Signal-to-Noise Ratio (SNR), explains how signal power fades with range and system losses and how processing gains from pulse compression and coherent integration counter high noise floors. The chapter also defines many related concepts and terms
+
+  - **Chapter [<span class="underline">8</span>](08_sar_imagery_and_interpretation_considerations.md) SAR Imagery & Interpretation Considerations** explains the meaning of detection in SAR, and how SAR data actually consists of amplitude and phase value pairs. Backscatter, polarization and different scattering mechanisms and geometric distortions are discussed. The phenomena of speckle is illustrated and two notable image quality metrics are described.
+
+### Part 3: How is SAR Data Packaged and Used?
+
+**Part 3** focuses on data processing and analysis as well as data products. While the earlier chapters provide a great foundation for understanding SAR and related terminology, these final chapters are most relevant for the application oriented readers who want to understand how SAR can be practically utilized:
+
+  - **Chapter [<span class="underline">9</span>](09_data_processing_and_analysis.md) Data Processing and Metadata** describes the process of converting SAR data into different data product levels, and defines several related terms. It explains processing choices relating to sampling and sample arrangement, axis alignment, multi-looking, and projection surfaces. It also lists some common SAR data analysis and utilization techniques.
+
+  - **Chapter [<span class="underline">10</span>](10_data_products.md) Data Products** presents the most established data products on the market, from the early compensated phase history data products to newer colorized sub-aperture stack images and SAR Video.
+
+<figure id="figure-2-diversity">
+<img src="../img/media/image2.jpeg">
+<figcaption><strong>Figure 2: Diversity.</strong> A SAR image featuring a mountainous scene with agricultural and residential infrastructure. High quality SAR imagery can enable numerous detection, analysis, monitoring and planning use cases that may be instrumental in operations and research and sometimes also save countless lives.</figcaption>
+</figure>
+
+## Complementary Resources
+
+The SAR101: Foundations material is offered together with other complementary information resources:
+
+  - The [<span class="underline">Data Product Specification</span>](../productspecification/introduction.md) provides a business and application oriented overview and specification of the actual SAR data products that ICEYE offers. Compared to the SAR101, the specification documentation is more directly useful when starting to leverage SAR in partnership with ICEYE. However, to fully understand everything in it, studying SAR101 may be required.
+
+  - The [<span class="underline">Technical Documentation</span>](../techdocs/00_welcome.md) is tailored to more advanced users of SAR, and provides information which is often more technical and generally more specific to ICEYE offerings. While SAR101 is curated to be read sequentially from top to bottom, the Technical Documentation is a collection of mostly independent chapters that can be consumed in any order. They are intended for experienced users and SAR experts, who often are only interested in very specific portions of the documentation, and are sometimes already familiar with the other resources.
+
+  - The [<span class="underline">Archives</span>](../archive/archive.md) provides documentation that is deemed deprecated but is nonetheless offered in case of interest.
+
+  - The [<span class="underline">Glossary</span>](../glossary.md) defines many terms that are used in these documents and are relevant to SAR. The definitions are intended to help reduce confusion and inefficiency in SAR related communication.
+
+## Feedback
+
+All this material is written to serve your information needs. Any feedback that helps us improve this material is appreciated.

--- a/docs/sar101/01_introduction.md
+++ b/docs/sar101/01_introduction.md
@@ -108,13 +108,13 @@ In SLAR, the azimuth resolution—the ability to distinguish targets along the f
 
 Again, azimuth resolution in SLAR is based on the angular width of the pulse in the azimuth direction (represented by ꞵ in Figure 1[<span class="underline">.</span>](#_jupbwsyrzbec)3). Antennas that are long in the azimuth direction create narrow beams, which focus the signal and enable the detection of individual objects. However, even a narrow beam spreads out as it propagates from the antenna to the distant ground surface (See Figure [<span class="underline">1.4</span>](#figure-1.4-slar-pulse-dimensions)). In a RAR system, azimuth resolution is much better in the <span class="underline">near range</span> than the <span class="underline">far range</span>, illustrated by the following equation:
 
-\[delta_{\text{az}} = \frac{R\lambda}{L} = \frac{H\lambda}{L\sin\gamma}\]
+\[\delta_{\text{az}} = \frac{R\lambda}{L} = \frac{H\lambda}{L\sin\gamma}\]
 
 Here, \(R\) is the slant range, \(\lambda\) is the wavelength used by the radar, and \(L\) is the physical length of the antenna in the azimuth direction. In the second representation slant range is replaced with \(H\), the altitude of the airplane or the height of the imaging platform, and we introduce \(\gamma\), the slant or *depression angle* (the angle between the dotted vertical line and the beam in Figure [<span class="underline">1.3</span>](#real-aperture-and-side-looking-airborne-radar)), to make the equation reflect the SLAR use case.
 
 Ground range resolution in SLAR is independent from azimuth resolution, and is based on pulse length (see Figure [<span class="underline">1.4</span>](#figure-1.4-slar-pulse-dimensions)). The equation is as follows:
 
-\[delta_{\text{gr}} = \frac{\tau c}{2\cos\gamma}\]
+\[\delta_{\text{gr}} = \frac{\tau c}{2\cos\gamma}\]
 
 Here, \(\tau\) is the radar pulse duration and \(c\) is the speed of light.
 
@@ -125,9 +125,9 @@ Here, \(\tau\) is the radar pulse duration and \(c\) is the speed of light.
 
 To illustrate the differences in resolution in azimuth and range, let us examine an airborne system. This example uses an airplane flying at an altitude of 3 km with a RAR system with a 1 microsecond pulse duration, operating in [<span class="underline">L-band</span>](03_radar_frequency_bands.md) with a wavelength of 20 cm, with a 3 meter antenna at a 45° slant or depression angle. We achieve approximately the following azimuth and ground range resolutions:
 
-\[delta_{\text{az}} = \frac{H\lambda}{L\sin\gamma} = \frac{3000m \cdot 0.20m}{3m \cdot \sin 45{^\circ}} \approx 283m\]
+\[\delta_{\text{az}} = \frac{H\lambda}{L\sin\gamma} = \frac{3000m \cdot 0.20m}{3m \cdot \sin 45{^\circ}} \approx 283m\]
 
-\[delta_{\text{gr}} = \frac{\tau c}{2\cos\gamma} = \frac{1\mu s \cdot 299792458\frac{m}{s}}{2 \cdot \cos 45{^\circ}} \approx 212m\]
+\[\delta_{\text{gr}} = \frac{\tau c}{2\cos\gamma} = \frac{1\mu s \cdot 299792458\frac{m}{s}}{2 \cdot \cos 45{^\circ}} \approx 212m\]
 
 These values highlight the limitations of SLAR, which uses a small physical antenna. It produces images with resolution in the hundreds of meters, even from relatively low flying aircraft. Such images could not even distinguish city blocks let alone individual buildings from one another. Applying the same techniques would have had serious limitations when it came time to move from airborne to spaceborne systems. To achieve a high resolution image of about 0.3 meters using an X-band (\~3 cm wavelength) antenna in space, an ultra short pulse duration of about 2 nanoseconds and an antenna about 75 kilometers long would be required. Obviously, these are in no way feasible engineering parameters\!
 

--- a/docs/sar101/01_introduction.md
+++ b/docs/sar101/01_introduction.md
@@ -1,0 +1,161 @@
+# Introduction to SAR
+
+!!! summary
+
+    - Radar is a form of active remote sensing where a radar system emits electromagnetic radiation and records the returned echoes which can be used to form images of distant objects and areas.
+
+    - A Real Aperture Radar (RAR) is limited by the size of its physical antenna, and engineers can only build and deploy antennas of a certain size.
+
+    - The innovation of Synthetic Aperture Radar (SAR) solves this limitation by using the motion of a platform (either an aircraft or satellite) to collect and combine radar echos to synthesize a very long antenna, which makes it possible to generate high resolution images.
+
+    - SAR systems look to the side to get unique range values, or distance measurements, for each object on the ground. This is important for distinguishing objects from each other during data collection, but can impact the appearance of the image (distortions).
+
+    - The resolution of a radar image is based on two components that are independent of each other: range resolution (which depends on pulse bandwidth) and azimuth resolution (which depends on the size of the antenna and the emitted wavelength).
+
+<span class="underline">Synthetic Aperture Radar (SAR)</span> is a remote sensing method unique in its ability to image day and night, and in all weather conditions. While optical imagery uses light from the sun to illuminate the surface, SAR and other radar systems are <span class="underline">active sensors</span>: they emit their own energy in the form of electromagnetic radiation (in the microwave region) to illuminate a scene and then measure the returned echo. See Figure [<span class="underline">1.1</span>](#figure-1.1-passive-and-active-remote-sensing) for an illustrative comparison of passive and active remote sensing.
+
+<figure id="figure-1.1-passive-and-active-remote-sensing">
+<img src="../img/media/image3.png">
+<figcaption><strong>Figure 1.1: Passive and Active Remote Sensing.</strong> Passive sensing systems leverage the sun’s powerful illumination while active systems benefit from independence, allowing all-weather, day-night imaging and coherent measurements.</figcaption>
+</figure>
+
+SAR uses microwave wavelengths to produce very high-resolution images of the Earth’s surface from both air and space regardless of weather. The essence of SAR is that by collecting radar measurements sequentially along a system’s flight path and then processing the returned echoes together, we synthesize a large “virtual” antenna. Since spatial resolution is directly proportional to antenna length, SAR thereby enables the generation of images with spatial resolutions that would otherwise require infeasibly long antennas.
+
+This chapter explains this principle further, introduces several foundational terms, and outlines the history of SAR.
+
+## 1.1) Radar Imaging, Antenna Aperture, and Beamwidth
+
+The fundamental capabilities of radar stem from its ability to measure the distance and direction of electromagnetic echoes, allowing it to map its surroundings.
+
+Radar is an acronym meaning <span class="underline">RAdio Detection And Ranging (RADAR)</span>. A radar transmitter emits electromagnetic radiation—typically in the form of radio or microwave signals—toward a target, and the reflected echoes are captured by a receiver. This is the *detection* part of radar. The time delay between emission and receipt of each signal is precisely measured and used to calculate distances to each target in the scene. Because electromagnetic waves travel at the speed of light, we can determine how far away an object is by multiplying the time it takes for the signal to return by the speed of light—then dividing by two, since the signal travels to the target and back. Determining the distance to a target is called *ranging. *
+
+While measuring the distance from a sensor to a target is valuable, distance alone does not provide enough information for locating objects. To more precisely locate the source of a radar echo, we need additional information. In radar systems, this can be achieved using a directive <span class="underline">antenna</span>. A directive antenna focuses transmitted (and received) energy more in some directions than others, forming what is known as a <span class="underline">beam pattern</span>. This allows the radar to illuminate and receive signals from specific directions, enabling angular discrimination. Using this property, we can determine the angle of arrival of incoming echoes. When range and angle measurements are combined, they form a two-dimensional representation of the reflected microwave energy—what we refer to as a <span class="underline">radar image</span>.
+
+It is important to understand that an image is constructed from the <span class="underline">backscatter</span>—the reflected signals or echoes—of radar pulses transmitted by the sensor. These pulses are emitted at a regular rate called the <span class="underline">Pulse Repetition Frequency (PRF)</span>, which typically ranges from a few hundred pulses per second in airborne systems to several thousand in spaceborne platforms. After each pulse is transmitted, the radar receives echoes from objects on the ground. The collection of these echoes forms a range profile, representing the distribution of reflected energy at different distances from the radar. This <span class="underline">range profile</span> corresponds to a single line in the final radar image, capturing information from the area illuminated by that specific pulse (shown as the shaded area in Figure [<span class="underline">1.3</span>](#figure-1.3-side-looking-airborne-radar-slar)). As the radar platform moves forward and continues transmitting pulses, a sequence of range profiles is recorded and assembled into a two-dimensional radar image.
+
+The range measurements are collected perpendicular to the flight direction, in the <span class="underline">slant range direction</span>, which is the line of sight direction between the radar and a scatterer on the surface. The word *slant* comes from the fact that the side-looking radar mounted on an airplane is inclined, or slanted, to measure surface returns. The ability to distinguish range variations to different objects is represented by the <span class="underline">slant range resolution</span>, and it is determined by the length of the transmitted pulses. Figure [<span class="underline">1.3</span>](#figure-1.3-side-looking-airborne-radar-slar) also shows <span class="underline">ground range resolution</span> which is the slant range resolution projected to the ground plane.
+
+These three resolutions – azimuth, slant range and ground range – are introduced here, but their genesis is discussed in more depth in Chapter [<span class="underline">6</span>](06_spatial_resolution_and_geospatial_accuracy.md). Note that sometimes the word *slant* or *ground* is omitted and only the word *range* is used and one must use context to deduce which term is being discussed.
+
+In imaging systems such as those used in optics, photography, microscopy, and astronomy, the <span class="underline">aperture</span> refers to the physical opening (or collecting area) through which waves (typically light) are gathered. This aperture defines the spatial extent of the incoming wavefront that the system captures. The larger the aperture, the more of the wavefront is collected and coherently summed by the lens, which enables the system to better focus energy or <span class="underline">signal power</span> into a sharp point on the image plane. This focusing ability has a direct impact on the <span class="underline">spatial resolution</span> of the data collected by the system—and thereby, the ability to distinguish fine details or closely spaced objects. We will discuss resolution more in Chapter [<span class="underline">6</span>](06_spatial_resolution_and_geospatial_accuracy.md).
+
+In radar, the aperture refers to the area of the antenna that captures incoming electromagnetic waves. This area defines the spatial extent of the wavefront being received and thus determines how sharply the waves can be summed or focused in a particular direction. The result of this wave summation is the beam pattern of the antenna: a directional sensitivity profile that dictates how well the radar can resolve targets at different angles.
+
+Just as a larger optical aperture can lead to finer spatial detail, a larger radar antenna leads to a narrower beam, and therefore better angular resolution. In both cases, the aperture governs how well the system can distinguish fine spatial features. In radar, when a single antenna is used for both transmitting and receiving—common in <span class="underline">monostatic</span> radar systems, including most Synthetic Aperture Radar (SAR) satellites—the aperture impacts resolution and sensitivity twice: once during transmission and again during reception.
+
+!!! note
+    A radar where the receiver and transmitter have their own antennas and are physically separate and distant is called a <span class="underline">bistatic radar</span>. Moreover, a system that fuses data from multiple spatially distributed monostatic and/or bistatic radars is called a <span class="underline">multistatic radar</span>.
+    
+    Synthetic aperture radar and multistatic radar share some principles and benefits: While a long effective aperture is synthesized in SAR using the motion of the radar, multistatic radar also synthesizes a large effective aperture using multiple radars situated apart. Both require advanced computational processing to *synthesize* and fuse the data but typically produce much better imaging results than stationary monostatic radars.
+    
+    Note also that multistatic radar and SAR are not mutually exclusive: An even more powerful <span class="underline">effective aperture</span> can be synthesized with a multistatic SAR system, where data is fused from multiple spatially distributed antennas that also move!
+
+Figure [<span class="underline">1.2</span>](#figure-1.2-basic-radar-imaging-terms) illustrates basic concepts relating to monostatic radar: <span class="underline">Antenna aperture</span> refers to the physical dimensions of the antenna, which for rectangular antennas are defined as width and length. <span class="underline">Beamwidth</span> defines the angular spread of an antenna's radiated and received signal power. The beamwidth of an antenna is inversely proportional to its aperture size.
+
+<figure id="figure-1.2-basic-radar-imaging-terms">
+<img src="../img/media/image4.png">
+<figcaption><strong>Figure 1.2: Basic Radar Imaging Terms.</strong></figcaption>
+</figure>
+
+Before delving further into the principles of radar imaging, it is helpful to first define some essential terminology illustrated in Figure [<span class="underline">1.2</span>](#figure-1.2-basic-radar-imaging-terms). <span class="underline">Illumination</span> refers to the fact that objects on the surface can become visible to the radar only if they interact with the transmitted signal. The energy that returns back to the sensor is called <span class="underline">backscatter</span> and it is the signal data that is measured and received by the antenna to form an image. A <span class="underline">scatterer</span> is anything in the scene that scatters the incoming microwave signal. A ground feature that blocks the illumination of other scatterers creates a radar <span class="underline">shadow</span> which prevents the area in the shadow from being imaged. <span class="underline">Range</span> refers to the distance between the radar and specific targets or points in a scene. The <span class="underline">azimuth</span> angle of a target is defined as its angle relative to the antenna’s boresight in the horizontal plane.
+
+## 1.2) Side-Looking Illumination and Ranging
+
+Radar imaging systems illuminate the ground from the side rather than directly beneath the sensor. This technique, known as <span class="underline">Side-Looking Illumination (SLI)</span> or <span class="underline">Side-Looking Radar (SLR)</span>, is essential because radar determines the position of targets based on the *time delay* of returned signals—i.e., by measuring range.
+
+!!! note inline end
+    The Line-Of-Sight (LOS) refers to the path travelled by the medium of sight – typically electromagnetic waves – from the target to the observer, or sensor. In simple cases, the LOS is a straight line, but it may be curved or segmented due to refraction, reflection, or obstructions in the environment, in which case the observer might incorrectly estimate the target’s location.
+
+If the radar were to look straight down (nadir), then for targets lying on a flat ground surface, the differences in range between nearby points would be extremely small. This would make it nearly impossible to distinguish between them based on signal travel time, resulting in poor or no resolution on the ground plane. By contrast, a side-looking geometry introduces greater variation in the slant range to different points on the ground, even if the surface is flat. These differences in distance translate into measurable time delays in the returned signal, allowing the radar to reliably separate targets in the range direction. In other words, side-looking geometry ensures that variations in target distance translate into measurable time delays, enabling reliable range discrimination.
+
+For example, the two purple diamonds in the vertical illumination illustration in Figure [<span class="underline">1.3</span>](#figure-1.3-vertical-vs-side-looking-illumination) would be represented as a single pixel in the image despite occupying unique ground positions. Radar imaging must therefore be side-looking so that all ground points from the <span class="underline">near range</span> – the edge of the scene closest to the radar – all the way to the <span class="underline">far range</span> – the edge of the scene farthest from the radar – have different range values (assuming flat terrain). Pixels in a radar image are placed on the image based partly on their range, or distance, from the sensor along the radar line of sight.
+
+This constraint has important geometric consequences for radar images, which we’ll explore in more detail later. Unlike optical systems—which passively capture images in a plane perpendicular to the direction of incoming light—radar systems actively form images using ranging. One dimension of the radar image, the *range direction*, lies along the direction of illumination itself. This results in a unique and sometimes counterintuitive image geometry that distinguishes radar from traditional optical imaging systems.
+
+<figure id="figure-1.3-vertical-vs-side-looking-illumination">
+<div class="figure-row">
+  <img src="../img/media/image5.png" alt="Vertical looking illumination">
+  <img src="../img/media/image6.png" alt="Side-looking illumination">
+</div>
+<figcaption><strong>Figure 1.3: Vertical vs Side-Looking Illumination.</strong> Radar imaging must be side-looking so that ground points from the near to far range have mostly different range values. The illumination is typically broadside, or perpendicular, to the flight direction.</figcaption>
+</figure>
+
+## 1.3) Real Aperture and Side-Looking Airborne Radar
+
+In this section we will discuss the basics of Real Aperture Radar (RAR), as well as the limitations of RAR which led to the development of spaceborne SAR.
+
+<span class="underline">Real Aperture Radar (RAR)</span> can be thought of as the most straightforward form of radar imaging. In its simplest form, RAR involves a radar system transmitting pulses and recording the time it takes for echoes to return, thereby measuring the range to targets. When the radar is stationary, this range information is very accurate and straightforward to compute. However, determining the position of targets in the <span class="underline">azimuth</span> (or <span class="underline">cross-range</span>) direction—perpendicular to the line of sight (see Figure [<span class="underline">1.3</span>](#figure-1.3-side-looking-airborne-radar-slar))—is a completely separate, independent and much more challenging task.
+
+<span class="underline">Resolution</span> refers to the ability to distinguish between two closely spaced objects (We will discuss resolution more in Chapter [<span class="underline">6</span>](06_spatial_resolution_and_geospatial_accuracy.md), but we touch on it here to help explain why system design needed to evolve) or signals (tackled in Chapter [<span class="underline"> 7</span>](07_separating_signals_from_noise.md#75-radiometric-resolution-quantization-and-dynamic-range) when discussing radiometric resolution). When discussing resolution in SAR images, we are often referring to spatial resolution. Spatial resolution is dependent on two independent measures of resolution: range and azimuth resolution. While range resolution in RAR can be made quite precise using short pulses, azimuth resolution is fundamentally limited by the size of the antenna and the way it captures angular information. A RAR system can be used to produce a two-dimensional range-azimuth image in different ways:
+
+1.  **Rotating the antenna**: By sweeping the radar beam in a circular or sector pattern, the system effectively builds up a two-dimensional image by observing the scene from multiple angles. This technique is commonly used in weather radar (e.g., precipitation mapping) and marine surveillance, where targets are relatively close and resolution requirements are modest. However, as distance to the target increases, the angular spread of the radar beam causes the cross-range resolution to degrade significantly.
+
+2.  **Moving the antenna**: When the radar is mounted on a moving platform—such as a vehicle, ship, or aircraft—it can record backscatter from different points on the ground as it moves forward. The radar can build up an intensity map of the scene in the azimuth direction simply by collecting and storing these echoes along the path of motion.
+
+Even with a very large stationary antenna, azimuth resolution of RAR is still limited. A larger antenna produces a narrower beam which helps focus energy, but the beam still widens with distance. This results in range-dependent resolution: high resolution near the radar, and poorer resolution farther away. While this can be useful for identifying large objects, RAR is not able to generate high resolution images.
+
+!!! note inline end
+    The terms azimuth, along-track, azimuthal, and cross-range are often used interchangeably in radar literature. They all refer to the same direction—parallel to the motion of the radar platform.
+
+The first widely used ground imaging real aperture radars were side-looking and mounted on aircraft, and were consequently referred to as <span class="underline">Side-Looking Airborne Radar (SLAR)</span>. Not only did the aircraft provide the RAR a larger view of the surface, but its steady movement made it possible to build a two-dimensional image one straight line at a time (see Figure [<span class="underline">1.3</span>](#figure-1.3-side-looking-airborne-radar-slar)). Azimuth resolution was relatively consistent between the near and far range due to the high altitude of the platform relative to the size of the scene in range.
+
+In SLAR, the azimuth resolution—the ability to distinguish targets along the flight path—is determined by the angular width of the radar beam on the ground in the azimuth direction (i.e., the direction of flight). This angular width depends on the beamwidth of the antenna in that direction, which in turn is governed by the physical size of the antenna: a larger antenna produces a narrower beam and thus better azimuth resolution.
+
+<figure id="figure-1.3-side-looking-airborne-radar-slar">
+<img src="../img/media/image7.png">
+<figcaption><strong>Figure 1.3: Side-Looking Airborne Radar (SLAR).</strong> As the platform advances along the azimuth direction, each pulse emitted in the slant plane results in the collection of another range profile, spanning echoes from each point between the near and the far range.</figcaption>
+</figure>
+
+Again, azimuth resolution in SLAR is based on the angular width of the pulse in the azimuth direction (represented by ꞵ in Figure 1[<span class="underline">.</span>](#_jupbwsyrzbec)3). Antennas that are long in the azimuth direction create narrow beams, which focus the signal and enable the detection of individual objects. However, even a narrow beam spreads out as it propagates from the antenna to the distant ground surface (See Figure [<span class="underline">1.4</span>](#figure-1.4-slar-pulse-dimensions)). In a RAR system, azimuth resolution is much better in the <span class="underline">near range</span> than the <span class="underline">far range</span>, illustrated by the following equation:
+
+\[delta_{\text{az}} = \frac{R\lambda}{L} = \frac{H\lambda}{L\sin\gamma}\]
+
+Here, \(R\) is the slant range, \(\lambda\) is the wavelength used by the radar, and \(L\) is the physical length of the antenna in the azimuth direction. In the second representation slant range is replaced with \(H\), the altitude of the airplane or the height of the imaging platform, and we introduce \(\gamma\), the slant or *depression angle* (the angle between the dotted vertical line and the beam in Figure [<span class="underline">1.3</span>](#real-aperture-and-side-looking-airborne-radar)), to make the equation reflect the SLAR use case.
+
+Ground range resolution in SLAR is independent from azimuth resolution, and is based on pulse length (see Figure [<span class="underline">1.4</span>](#figure-1.4-slar-pulse-dimensions)). The equation is as follows:
+
+\[delta_{\text{gr}} = \frac{\tau c}{2\cos\gamma}\]
+
+Here, \(\tau\) is the radar pulse duration and \(c\) is the speed of light.
+
+<figure id="figure-1.4-slar-pulse-dimensions">
+<img src="../img/media/image8.png">
+<figcaption><strong>Figure 1.4: SLAR Pulse Dimensions.</strong></figcaption>
+</figure>
+
+To illustrate the differences in resolution in azimuth and range, let us examine an airborne system. This example uses an airplane flying at an altitude of 3 km with a RAR system with a 1 microsecond pulse duration, operating in [<span class="underline">L-band</span>](03_radar_frequency_bands.md) with a wavelength of 20 cm, with a 3 meter antenna at a 45° slant or depression angle. We achieve approximately the following azimuth and ground range resolutions:
+
+\[delta_{\text{az}} = \frac{H\lambda}{L\sin\gamma} = \frac{3000m \cdot 0.20m}{3m \cdot \sin 45{^\circ}} \approx 283m\]
+
+\[delta_{\text{gr}} = \frac{\tau c}{2\cos\gamma} = \frac{1\mu s \cdot 299792458\frac{m}{s}}{2 \cdot \cos 45{^\circ}} \approx 212m\]
+
+These values highlight the limitations of SLAR, which uses a small physical antenna. It produces images with resolution in the hundreds of meters, even from relatively low flying aircraft. Such images could not even distinguish city blocks let alone individual buildings from one another. Applying the same techniques would have had serious limitations when it came time to move from airborne to spaceborne systems. To achieve a high resolution image of about 0.3 meters using an X-band (\~3 cm wavelength) antenna in space, an ultra short pulse duration of about 2 nanoseconds and an antenna about 75 kilometers long would be required. Obviously, these are in no way feasible engineering parameters\!
+
+!!! history
+    Note that while both azimuth and range resolution are showcased in the above examples as limiting factors, the challenge with range resolution was quickly resolved: In the 1950s, scientists and engineers invented a set of *intra-pulse modulation* techniques, namely *pulse chirping* (explained in Section [<span class="underline">6.2</span>](06_spatial_resolution_and_geospatial_accuracy.md/#62-range-resolution-pulse-chirping-and-pulse-bandwidth)), to effectively *compress* or shorten pulses further without reducing their total energy content and recognizability, and thus without making it overly difficult to receive and distinguish their echoes as they returned to the radar. These innovations greatly improved range resolution and have therefore been leveraged by both RAR and SAR systems ever since. However, the challenge with azimuth resolution remained for years longer, until the invention of aperture synthesis.
+
+## 1.4) The Invention of Aperture Synthesis
+
+We have established that for SLAR, an infeasibly huge antenna would be required to create the aperture and the narrow radar beam necessary for high azimuth resolution. However, an invention by mathematician Carl A. Wiley and subsequent development by Emmett N. Leith and others during the 1950s proved that a huge physical antenna was not needed.
+
+Instead, it is possible to use a small physical antenna to emit a large number of pulses throughout a precisely known trajectory. By applying a computational post-processing scheme to all the data collected, an enormous *synthetic aperture* enabling very fine azimuth resolution can be created. When all of the measurements are stored and processed together, it is as if they were collected from one antenna equal in length to the whole trajectory through which echoes were received.
+
+This technique is called <span class="underline">Synthetic Aperture Radar (SAR)</span> and it has become so pervasive in radar imaging that the non-synthesizing method is now called *real aperture* radar imaging (as presented in the previous section) in order to be clear. Indeed, the invention of SAR has been foundational not only to the genesis of spaceborne radar imaging but to various other radar imaging applications.
+
+The long extent of the synthetic aperture allows for the combination of many wave measurements to produce a very narrow azimuth beamwidth, which is the key to achieving high resolution. In an optical system, a lens or mirror collects and focuses light waves from different points across the aperture, enabling high-resolution imaging. In SAR, a similar physical principle is applied: electromagnetic waves received at different positions along the flight path (aperture) are combined to form a focused image. However, instead of doing this physically, SAR performs the summation digitally, by combining the recorded voltage signals from each pulse. In this way, the signal processor plays the same role that a lens or objective does in an optical system.
+
+Figure [<span class="underline">1.5</span>](#figure-1.5-linear-extent-of-recording-locations) shows a radar antenna sequentially emitting a series of pulses and recording the echoes from a series of sequential receive positions. In the resulting image, these echoes are integrated to form a representation of the scatterers on the surface.
+
+<figure id="figure-1.5-linear-extent-of-recording-locations">
+<img src="../img/media/image9.png">
+<figcaption><strong>Figure 1.5: Linear Extent of Recording Locations.</strong></figcaption>
+</figure>
+
+The synthetic aperture length is approximately:
+
+\[L_{\text{syn}} = vT\]
+
+Where \(v\) is the platform velocity, and \(T\) is the time over which signal pulse transmission and receipt data is coherently processed and integrated. In Chapter [<span class="underline">2</span>](02_satellite_orbits_and_constellations.md) it is explained that a typical SAR satellite might orbit the Earth at an altitude of roughly 600 km with an orbital velocity of roughly 8 km/s. Consequently, over a 25 second illumination period, a synthetic aperture length of about 200 km is generated. A 200km long synthetic aperture is clearly well suited for generating high resolution radar imagery from spaceborne systems.
+
+!!! history
+    The inventor Carl. A. Wiley’s work at Goodyear Aircraft Company demonstrated the earliest pioneering SAR systems in the 1950s, and by the 1970s, NASA/JPL started to work on the Airborne Imaging Radar (AIR) that showcased the utility of L-band SAR for Earth science experiments. Finally, in 1978 the first spaceborne SAR mission was launched, the SEASAT-A developed jointly by NASA and JPL, and it demonstrated how vast synthetic apertures can be created in space to provide relatively high resolution Earth imagery.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -89,8 +89,56 @@ th {
 
 .md-grid {
     max-width: 1580px; 
-  }
+}
 
 [data-md-color-scheme="slate"] {
     --md-hue: 180; 
-  }
+}
+
+span.underline {
+    text-decoration: underline;
+}
+
+mjx-assistive-mml mjx-container {
+    /*  MathJax creates mjx-assistive-mml elements to contain invisible
+    MathML representations for screen reader tools for the visually
+    impaired. However, the top/bottom margin makes this invisible
+    element take space which often results in an unnecessary vertical
+    scrollbar to appear on the right side of the math, which is why here
+    we eliminate the vertical margins. */
+    margin: 0 !important;
+}
+
+/* Customizations for the "summary" admonition used in SAR101 and Tech Docs */
+
+@media screen and (min-width: 960px) {
+    .md-typeset .admonition.summary.inline.end,
+    .md-typeset details.summary.inline.end {
+      width: 42%;
+      margin-left: 1rem;
+
+    }
+}
+
+.md-typeset .admonition.summary > .admonition-title {
+    background-color: var(--md-primary-fg-color--dark);
+    color: white;
+}
+
+.md-typeset .admonition.summary,
+.md-typeset details.summary {
+    border-left-color: var(--md-primary-fg-color--dark);
+}
+
+/* Customizations to enable the rendering of two images in a row */
+
+.md-typeset .figure-row {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+}
+
+.md-typeset .figure-row img {
+    width: 38%; /* Override the width in the HTML if this is not ideal (e.g. more than two images) */
+    height: auto;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,9 @@ nav:
 #            - SAR Video : productFormats/vid.md
 #        - Upcoming Formats : productFormats/upcomingformats.md
     - Metadata Reference: productFormats/metadata.md
+#    - SAR 101 NEW :
+#      - Welcome : sar101/00_welcome.md
+#      - 1) Introduction to SAR : sar101/01_introduction.md
     - SAR 101 : 
       - What is SAR ? : 
           - The Value Of SAR Imaging : foundations/OverviewOfSAR/overviewOfSAR.md
@@ -107,6 +110,9 @@ extra:
     provider: google
     property: G-G92GBM9X22
   homepage: https://www.iceye.com/
+  admonition:
+    summary: abstract # This instructs MkDocs to define "summary" as a copy of
+                      # the built-in "abstract" admonition
 
 
 extra_css:


### PR DESCRIPTION
This PR kickstarts a SAR101 documentation renewal.

Scope:
- Adds SAR101 Welcome page + Chapter 1
- Adds supporting CSS for slightly stylized admonitions
- Adds corresponding MkDocs navigation spec lines but leaves them commented out to not advertise the material at the site
- Uses GitHub release assets as a temporary image hosting workaround for just two images for testing purposes

Context:
This is part of a larger effort to modernize the SAR101 documentation.
Content is being introduced incrementally to enable review before full publication.

What to review:
- Rendering in MkDocs (validated only locally by the author)

What to ignore:
- Most/all links are broken, most images do not render, formatting and style is not final --> Will be fixed later

Open topics (to discuss):
- Image hosting strategy (current workaround vs long-term solution)
- Final navigation structure and rollout approach
- Review and PR process

Plan:
- Follow-up PRs will add remaining chapters
- Finalization PRs will fix the links, images and update navigation and deprecate old SAR101 content